### PR TITLE
Users being able to manage their wishlists is now configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('multiple')->end()
                 ->booleanNode('default_public')->end()
+                ->booleanNode('account_manageable')->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/WebburzaSyliusWishlistExtension.php
+++ b/DependencyInjection/WebburzaSyliusWishlistExtension.php
@@ -20,6 +20,7 @@ class WebburzaSyliusWishlistExtension extends Extension
         // Set config parameters
         $container->setParameter('webburza_sylius_wishlist.multiple', $config['multiple']);
         $container->setParameter('webburza_sylius_wishlist.default_public', $config['default_public']);
+        $container->setParameter('webburza_sylius_wishlist.account_manageable', $config['account_manageable']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/EventListener/AccountMenuBuilderListener.php
+++ b/EventListener/AccountMenuBuilderListener.php
@@ -30,24 +30,32 @@ class AccountMenuBuilderListener
     protected $multipleWishlistMode;
 
     /**
+     * @var bool
+     */
+    protected $accountManageable;
+
+    /**
      * FrontendMenuBuilderListener constructor.
      *
      * @param TranslatorInterface $translator
      * @param TokenStorageInterface $tokenStorage
      * @param WishlistRepositoryInterface $wishlistRepository
      * @param $multipleWishlistMode
+     * @param $accountManageable
      */
     public function __construct(
         TranslatorInterface $translator,
         TokenStorageInterface $tokenStorage,
         WishlistRepositoryInterface $wishlistRepository,
-        $multipleWishlistMode
+        $multipleWishlistMode,
+        $accountManageable
     ) {
 
         $this->translator = $translator;
         $this->tokenStorage = $tokenStorage;
         $this->wishlistRepository = $wishlistRepository;
         $this->multipleWishlistMode = $multipleWishlistMode;
+        $this->accountManageable = $accountManageable;
     }
 
     /**
@@ -57,6 +65,10 @@ class AccountMenuBuilderListener
      */
     public function addAccountMenuItems(MenuBuilderEvent $event)
     {
+        if (!$this->accountManageable) {
+            return;
+        }
+
         // Get the menu
         $menu = $event->getMenu();
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ to use single or multiple wishlists per user, which can be public or private.
   webburza_sylius_wishlist:
       multiple: true           # multiple wishlist mode
       default_public: false    # used for automatically created wishlists
+      account_manageable: true # users can manage their wishlists in their account
   ```
 
   4. register routes in `app/config/routing.yml`

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,6 +11,7 @@ services:
             - '@security.token_storage'
             - '@webburza_wishlist.repository.wishlist'
             - '%webburza_sylius_wishlist.multiple%'
+            - '%webburza_sylius_wishlist.account_manageable%'
         tags:
             - { name: kernel.event_listener, event: sylius.menu.shop.account, method: addAccountMenuItems }
 


### PR DESCRIPTION
Currently all users are able to manage their wishlist in their account.
When having only one wishlist per account this seems to be a bit redundant. I wanted to disable the menu link in the account, but this didn't seem possible yet.

Here's a PR which makes it configurable for users to manage their wishlist in their account.