### PR TITLE
Fix incompatibility with Sylius 1.1

### DIFF
--- a/Model/Wishlist.php
+++ b/Model/Wishlist.php
@@ -3,14 +3,14 @@
 namespace Webburza\Sylius\WishlistBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Gedmo\Timestampable\Traits\Timestampable;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
+use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\User\Model\UserInterface;
 
 class Wishlist implements WishlistInterface
 {
-    use Timestampable;
+    use TimestampableTrait;
 
     /**
      * @var integer
@@ -146,7 +146,7 @@ class Wishlist implements WishlistInterface
     /**
      * @return ShopUserInterface
      */
-    public function getUser()
+    public function getUser(): ?UserInterface
     {
         return $this->user;
     }
@@ -156,7 +156,7 @@ class Wishlist implements WishlistInterface
      *
      * @return Wishlist
      */
-    public function setUser(UserInterface $user = null)
+    public function setUser(?UserInterface $user = null)
     {
         $this->user = $user;
 

--- a/Model/WishlistItem.php
+++ b/Model/WishlistItem.php
@@ -2,15 +2,14 @@
 
 namespace Webburza\Sylius\WishlistBundle\Model;
 
-use Gedmo\Timestampable\Traits\Timestampable;
 use Sylius\Component\Core\Model\ProductVariantInterface;
-use Symfony\Component\Validator\Constraints as Assert;
+use Sylius\Component\Resource\Model\TimestampableTrait;
 use Webburza\Sylius\WishlistBundle\Model\WishlistInterface;
 use Webburza\Sylius\WishlistBundle\Model\WishlistItemInterface;
 
 class WishlistItem implements WishlistItemInterface
 {
-    use Timestampable;
+    use TimestampableTrait;
 
     /**
      * @var integer

--- a/Resources/config/doctrine/Wishlist.orm.xml
+++ b/Resources/config/doctrine/Wishlist.orm.xml
@@ -23,7 +23,7 @@
             <gedmo:timestampable on="create"/>
         </field>
 
-        <field name="updatedAt" column="updated_at" type="datetime">
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
             <gedmo:timestampable on="update"/>
         </field>
 

--- a/Resources/config/doctrine/WishlistItem.orm.xml
+++ b/Resources/config/doctrine/WishlistItem.orm.xml
@@ -15,7 +15,7 @@
             <gedmo:timestampable on="create"/>
         </field>
 
-        <field name="updatedAt" column="updated_at" type="datetime">
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
             <gedmo:timestampable on="update"/>
         </field>
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "psr-4": { "Webburza\\Sylius\\WishlistBundle\\": "" }
     },
     "require": {
+        "php": "^7.1",
         "sylius/core": "^1.0@dev"
     },
     "require-dev": {


### PR DESCRIPTION
- require PHP 7.1
- update signature of Wishlist::getUser() method
- update signature of Wishlist::setUser() method
- use Sylius TimestampableTrait in Wishlist and WishlistItem
- update "createAt" mapping definition